### PR TITLE
Add basic support for non-image attachments

### DIFF
--- a/components/AttachmentOther.js
+++ b/components/AttachmentOther.js
@@ -18,7 +18,6 @@ const AttachmentOther = ({ id }) => {
           display: block;
           margin-bottom: 0.5rem;
         }
-        
       `}</style>
     </a>
   );

--- a/components/AttachmentOther.js
+++ b/components/AttachmentOther.js
@@ -16,11 +16,7 @@ const AttachmentOther = ({ id }) => {
       <style jsx>{`
         a {
           display: block;
-          padding: 1px;
           margin-bottom: 0.5rem;
-          min-width: 36px;
-          min-height: 1rem;
-          font-size: 0.8rem;
         }
         
       `}</style>

--- a/components/AttachmentOther.js
+++ b/components/AttachmentOther.js
@@ -1,0 +1,31 @@
+import { useSelector } from 'react-redux';
+
+const AttachmentOther = ({ id }) => {
+  const attachment = useSelector(state => state.attachments[id]);
+
+  if (!attachment) {
+    return null;
+  }
+
+  const { url, fileName, fileSize } = attachment;
+
+  return (
+    <a href={url} title={fileSize + ' b'} target="_blank" rel="noopener">
+      {fileName}
+
+      <style jsx>{`
+        a {
+          display: block;
+          padding: 1px;
+          margin-bottom: 0.5rem;
+          min-width: 36px;
+          min-height: 1rem;
+          font-size: 0.8rem;
+        }
+        
+      `}</style>
+    </a>
+  );
+};
+
+export default AttachmentOther;

--- a/components/PostAttachments.js
+++ b/components/PostAttachments.js
@@ -4,26 +4,52 @@ import AttachmentImage from './AttachmentImage';
 
 const PostAttachments = ({ postId }) => {
   const attachmentIds = useSelector(state => state.posts[postId].attachmentIds);
+
   if (attachmentIds.length === 0) {
     return false;
   }
+
   return <PostAttachmentsNotEmpty attachmentIds={attachmentIds}/>
 };
 
 const PostAttachmentsNotEmpty = ({ attachmentIds }) => {
+  const attachments = useSelector(state => state.attachments);
+  let attachmentsAudio = [];
+  let attachmentsPicture = [];
+
+  for (let attachmentId of attachmentIds) {
+    if (attachments[attachmentId].mediaType && attachments[attachmentId].mediaType === 'audio') {
+      attachmentsAudio.push(attachmentId);
+    } else {
+      attachmentsPicture.push(attachmentId);
+    }
+  }
+
   return (
     <section>
-      {attachmentIds.map(attId => (
+      {attachmentsAudio.map(attId => (
+        <a href={attachments[attId].url} title={attachments[attId].fileSize + ' b'}>{attachments[attId].fileName}</a>
+      ))}
+
+      {attachmentsPicture.map(attId => (
         <AttachmentImage id={attId} key={attId}/>
       ))}
 
       <style jsx>{`
         section {
           grid-area: attachments;
-
+          display: block;
           padding: 0.15rem 0;
           margin-right: -0.5rem;
           margin-bottom: 0;
+        }
+        a {
+          display: block;
+          padding: 1px;
+          margin-bottom: 0.5rem;
+          min-width: 36px;
+          min-height: 1rem;
+          font-size: 0.8rem;
         }
       `}</style>
     </section>

--- a/components/PostAttachments.js
+++ b/components/PostAttachments.js
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import AttachmentImage from './AttachmentImage';
+import AttachmentOther from './AttachmentOther';
 
 const PostAttachments = ({ postId }) => {
   const attachmentIds = useSelector(state => state.posts[postId].attachmentIds);
@@ -32,7 +33,7 @@ const PostAttachmentsNotEmpty = ({ attachmentIds }) => {
       ))}
 
       {otherAttachments.map(attId => (
-        <a href={attachments[attId].url} title={attachments[attId].fileSize + ' b'} target="_blank" rel="noopener">{attachments[attId].fileName}</a>
+        <AttachmentOther id={attId} key={attId}/>
       ))}
 
       <style jsx>{`
@@ -42,14 +43,6 @@ const PostAttachmentsNotEmpty = ({ attachmentIds }) => {
           padding: 0.15rem 0;
           margin-right: -0.5rem;
           margin-bottom: 0;
-        }
-        a {
-          display: block;
-          padding: 1px;
-          margin-bottom: 0.5rem;
-          min-width: 36px;
-          min-height: 1rem;
-          font-size: 0.8rem;
         }
       `}</style>
     </section>

--- a/components/PostAttachments.js
+++ b/components/PostAttachments.js
@@ -39,6 +39,7 @@ const PostAttachmentsNotEmpty = ({ attachmentIds }) => {
       <style jsx>{`
         section {
           grid-area: attachments;
+          
           display: block;
           padding: 0.15rem 0;
           margin-right: -0.5rem;

--- a/components/PostAttachments.js
+++ b/components/PostAttachments.js
@@ -14,25 +14,25 @@ const PostAttachments = ({ postId }) => {
 
 const PostAttachmentsNotEmpty = ({ attachmentIds }) => {
   const attachments = useSelector(state => state.attachments);
-  let attachmentsAudio = [];
-  let attachmentsPicture = [];
+  const imageAttachments = [];
+  const otherAttachments = [];
 
   for (let attachmentId of attachmentIds) {
-    if (attachments[attachmentId].mediaType && attachments[attachmentId].mediaType === 'audio') {
-      attachmentsAudio.push(attachmentId);
+    if (attachments[attachmentId].mediaType && attachments[attachmentId].mediaType === 'image') {
+      imageAttachments.push(attachmentId);
     } else {
-      attachmentsPicture.push(attachmentId);
+      otherAttachments.push(attachmentId);
     }
   }
 
   return (
     <section>
-      {attachmentsAudio.map(attId => (
-        <a href={attachments[attId].url} title={attachments[attId].fileSize + ' b'}>{attachments[attId].fileName}</a>
+      {imageAttachments.map(attId => (
+        <AttachmentImage id={attId} key={attId}/>
       ))}
 
-      {attachmentsPicture.map(attId => (
-        <AttachmentImage id={attId} key={attId}/>
+      {otherAttachments.map(attId => (
+        <a href={attachments[attId].url} title={attachments[attId].fileSize + ' b'} target="_blank" rel="noopener">{attachments[attId].fileName}</a>
       ))}
 
       <style jsx>{`

--- a/components/PostAttachments.js
+++ b/components/PostAttachments.js
@@ -9,7 +9,6 @@ const PostAttachments = ({ postId }) => {
   if (attachmentIds.length === 0) {
     return false;
   }
-
   return <PostAttachmentsNotEmpty attachmentIds={attachmentIds}/>
 };
 
@@ -18,8 +17,8 @@ const PostAttachmentsNotEmpty = ({ attachmentIds }) => {
   const imageAttachments = [];
   const otherAttachments = [];
 
-  for (let attachmentId of attachmentIds) {
-    if (attachments[attachmentId].mediaType && attachments[attachmentId].mediaType === 'image') {
+  for (const attachmentId of attachmentIds) {
+    if (attachments[attachmentId].mediaType === 'image') {
       imageAttachments.push(attachmentId);
     } else {
       otherAttachments.push(attachmentId);
@@ -39,7 +38,6 @@ const PostAttachmentsNotEmpty = ({ attachmentIds }) => {
       <style jsx>{`
         section {
           grid-area: attachments;
-          
           display: block;
           padding: 0.15rem 0;
           margin-right: -0.5rem;

--- a/components/PostAttachments.js
+++ b/components/PostAttachments.js
@@ -5,7 +5,6 @@ import AttachmentOther from './AttachmentOther';
 
 const PostAttachments = ({ postId }) => {
   const attachmentIds = useSelector(state => state.posts[postId].attachmentIds);
-
   if (attachmentIds.length === 0) {
     return false;
   }
@@ -38,6 +37,7 @@ const PostAttachmentsNotEmpty = ({ attachmentIds }) => {
       <style jsx>{`
         section {
           grid-area: attachments;
+
           display: block;
           padding: 0.15rem 0;
           margin-right: -0.5rem;


### PR DESCRIPTION
Non-image attachments show up as links under the images:

![image](https://user-images.githubusercontent.com/66638374/175965584-09209085-8805-4628-a12a-d267a0c08118.png)
